### PR TITLE
add hostname to cache filenames

### DIFF
--- a/pypuppetdb_daily_report/pypuppetdb_daily_report.py
+++ b/pypuppetdb_daily_report/pypuppetdb_daily_report.py
@@ -85,7 +85,7 @@ def main(hostname, num_days=7, cache_dir=None, dry_run=False):
         end = query_date
         start = query_date - datetime.timedelta(days=1) + datetime.timedelta(seconds=1)
         date_s = (query_date - datetime.timedelta(hours=1)).astimezone(localtz).strftime('%a %m/%d')
-        date_data[date_s] = get_data_for_timespan(pdb, start, end, cache_dir=cache_dir)
+        date_data[date_s] = get_data_for_timespan(hostname, pdb, start, end, cache_dir=cache_dir)
         dates.append(date_s)
     html = format_html(hostname, dates, date_data, date_list[0], (date_list[-1] - datetime.timedelta(hours=23, minutes=59, seconds=59)))
     send_mail(html, dry_run=dry_run)
@@ -199,11 +199,13 @@ def filter_report_metric_format(o):
     return str(o)
 
 
-def get_data_for_timespan(pdb, start, end, cache_dir=None):
+def get_data_for_timespan(hostname, pdb, start, end, cache_dir=None):
     """
     Get the data for a specified timespan, from cache (if possible) or else
     from PuppetDB directly.
 
+    :param hostname: name of the puppetdb host we're connected to
+    :type hostname: string
     :param pdb: object representing a connected pypuppetdb instance
     :type pdb: one of the pypuppetdb.API classes
     :param start: beginning of time period to get data for
@@ -218,8 +220,9 @@ def get_data_for_timespan(pdb, start, end, cache_dir=None):
                                                                                               end=end.strftime('%Y-%m-%d_%H-%M-%S'),
                                                                                               ))
     if cache_dir is not None:
-        cache_filename = "data_{start}_{end}.pickle".format(start=start.strftime('%Y-%m-%d_%H-%M-%S'),
-                                                            end=end.strftime('%Y-%m-%d_%H-%M-%S'))
+        cache_filename = "data_{host}_{start}_{end}.pickle".format(host=hostname,
+                                                                   start=start.strftime('%Y-%m-%d_%H-%M-%S'),
+                                                                   end=end.strftime('%Y-%m-%d_%H-%M-%S'))
         cache_fpath = os.path.join(cache_dir, cache_filename)
         logger.debug("cache file: {fpath}".format(fpath=cache_fpath))
         if not os.path.exists(cache_dir):

--- a/pypuppetdb_daily_report/tests/pdr_test.py
+++ b/pypuppetdb_daily_report/tests/pdr_test.py
@@ -270,13 +270,14 @@ class Test_get_data_for_timespan:
                 mock.patch('pypuppetdb_daily_report.pypuppetdb_daily_report.query_data_for_timespan', query_mock), \
                 mock.patch('pypuppetdb_daily_report.pypuppetdb_daily_report.logger', logger_mock), \
                 mock.patch('pickle.loads', pickle_mock):
-            result = pdr.get_data_for_timespan(None,
+            result = pdr.get_data_for_timespan('foobar',
+                                               None,
                                                datetime.datetime(2014, 6, 10, hour=0, minute=0, second=0),
                                                datetime.datetime(2014, 6, 10, hour=23, minute=59, second=59),
                                                cache_dir='/tmp/cache')
         assert path_exists_mock.call_count == 2
         assert path_exists_mock.call_args_list == [mock.call('/tmp/cache'),
-                                                   mock.call('/tmp/cache/data_2014-06-10_00-00-00_2014-06-10_23-59-59.pickle')
+                                                   mock.call('/tmp/cache/data_foobar_2014-06-10_00-00-00_2014-06-10_23-59-59.pickle')
                                                    ]
         assert mock_open.call_count == 1
         fh = mock_open.return_value.__enter__.return_value
@@ -314,13 +315,14 @@ class Test_get_data_for_timespan:
                 mock.patch('pypuppetdb_daily_report.pypuppetdb_daily_report.query_data_for_timespan', query_mock), \
                 mock.patch('pypuppetdb_daily_report.pypuppetdb_daily_report.logger', logger_mock), \
                 mock.patch('pickle.dumps', pickle_mock):
-            pdr.get_data_for_timespan(None,
+            pdr.get_data_for_timespan('foobar',
+                                      None,
                                       datetime.datetime(2014, 6, 10, hour=0, minute=0, second=0),
                                       datetime.datetime(2014, 6, 10, hour=23, minute=59, second=59),
                                       cache_dir='/tmp/cache')
         assert os_mock.path.exists.call_count == 2
         assert os_mock.path.exists.call_args_list == [mock.call('/tmp/cache'),
-                                                      mock.call('/tmp/cache/data_2014-06-10_00-00-00_2014-06-10_23-59-59.pickle')
+                                                      mock.call('/tmp/cache/data_foobar_2014-06-10_00-00-00_2014-06-10_23-59-59.pickle')
                                                       ]
         assert os_mock.makedirs.call_count == 1
         assert os_mock.makedirs.call_args == mock.call('/tmp/cache')
@@ -364,13 +366,14 @@ class Test_get_data_for_timespan:
                 mock.patch('pypuppetdb_daily_report.pypuppetdb_daily_report.query_data_for_timespan', query_mock), \
                 mock.patch('pypuppetdb_daily_report.pypuppetdb_daily_report.logger', logger_mock), \
                 mock.patch('pickle.dumps', pickle_mock):
-            pdr.get_data_for_timespan(None,
+            pdr.get_data_for_timespan('foobar',
+                                      None,
                                       datetime.datetime(2014, 6, 10, hour=0, minute=0, second=0),
                                       datetime.datetime(2014, 6, 10, hour=23, minute=59, second=59),
                                       cache_dir='/tmp/cache')
         assert os_mock.path.exists.call_count == 2
         assert os_mock.path.exists.call_args_list == [mock.call('/tmp/cache'),
-                                                      mock.call('/tmp/cache/data_2014-06-10_00-00-00_2014-06-10_23-59-59.pickle')
+                                                      mock.call('/tmp/cache/data_foobar_2014-06-10_00-00-00_2014-06-10_23-59-59.pickle')
                                                       ]
         assert mock_open.call_count == 1
         fh = mock_open.return_value.__enter__.return_value
@@ -407,7 +410,8 @@ class Test_get_data_for_timespan:
                 mock.patch('pypuppetdb_daily_report.pypuppetdb_daily_report.query_data_for_timespan', query_mock), \
                 mock.patch('pypuppetdb_daily_report.pypuppetdb_daily_report.logger', logger_mock), \
                 mock.patch('pickle.dumps', pickle_mock):
-            pdr.get_data_for_timespan(None,
+            pdr.get_data_for_timespan('foobar',
+                                      None,
                                       datetime.datetime(2014, 6, 10, hour=0, minute=0, second=0),
                                       datetime.datetime(2014, 6, 10, hour=23, minute=59, second=59),
                                       cache_dir=None)
@@ -485,13 +489,13 @@ class Test_main:
 
         assert dft_mock.call_count == 7
         dft_expected = [
-            mock.call(pdb_mock, FakeDatetime(2014, 6, 10, hour=4, minute=0, second=0, tzinfo=pytz.utc), FakeDatetime(2014, 6, 11, hour=3, minute=59, second=59, tzinfo=pytz.utc), cache_dir=None),
-            mock.call(pdb_mock, FakeDatetime(2014, 6, 9, hour=4, minute=0, second=0, tzinfo=pytz.utc), FakeDatetime(2014, 6, 10, hour=3, minute=59, second=59, tzinfo=pytz.utc), cache_dir=None),
-            mock.call(pdb_mock, FakeDatetime(2014, 6, 8, hour=4, minute=0, second=0, tzinfo=pytz.utc), FakeDatetime(2014, 6, 9, hour=3, minute=59, second=59, tzinfo=pytz.utc), cache_dir=None),
-            mock.call(pdb_mock, FakeDatetime(2014, 6, 7, hour=4, minute=0, second=0, tzinfo=pytz.utc), FakeDatetime(2014, 6, 8, hour=3, minute=59, second=59, tzinfo=pytz.utc), cache_dir=None),
-            mock.call(pdb_mock, FakeDatetime(2014, 6, 6, hour=4, minute=0, second=0, tzinfo=pytz.utc), FakeDatetime(2014, 6, 7, hour=3, minute=59, second=59, tzinfo=pytz.utc), cache_dir=None),
-            mock.call(pdb_mock, FakeDatetime(2014, 6, 5, hour=4, minute=0, second=0, tzinfo=pytz.utc), FakeDatetime(2014, 6, 6, hour=3, minute=59, second=59, tzinfo=pytz.utc), cache_dir=None),
-            mock.call(pdb_mock, FakeDatetime(2014, 6, 4, hour=4, minute=0, second=0, tzinfo=pytz.utc), FakeDatetime(2014, 6, 5, hour=3, minute=59, second=59, tzinfo=pytz.utc), cache_dir=None),
+            mock.call('foobar', pdb_mock, FakeDatetime(2014, 6, 10, hour=4, minute=0, second=0, tzinfo=pytz.utc), FakeDatetime(2014, 6, 11, hour=3, minute=59, second=59, tzinfo=pytz.utc), cache_dir=None),
+            mock.call('foobar', pdb_mock, FakeDatetime(2014, 6, 9, hour=4, minute=0, second=0, tzinfo=pytz.utc), FakeDatetime(2014, 6, 10, hour=3, minute=59, second=59, tzinfo=pytz.utc), cache_dir=None),
+            mock.call('foobar', pdb_mock, FakeDatetime(2014, 6, 8, hour=4, minute=0, second=0, tzinfo=pytz.utc), FakeDatetime(2014, 6, 9, hour=3, minute=59, second=59, tzinfo=pytz.utc), cache_dir=None),
+            mock.call('foobar', pdb_mock, FakeDatetime(2014, 6, 7, hour=4, minute=0, second=0, tzinfo=pytz.utc), FakeDatetime(2014, 6, 8, hour=3, minute=59, second=59, tzinfo=pytz.utc), cache_dir=None),
+            mock.call('foobar', pdb_mock, FakeDatetime(2014, 6, 6, hour=4, minute=0, second=0, tzinfo=pytz.utc), FakeDatetime(2014, 6, 7, hour=3, minute=59, second=59, tzinfo=pytz.utc), cache_dir=None),
+            mock.call('foobar', pdb_mock, FakeDatetime(2014, 6, 5, hour=4, minute=0, second=0, tzinfo=pytz.utc), FakeDatetime(2014, 6, 6, hour=3, minute=59, second=59, tzinfo=pytz.utc), cache_dir=None),
+            mock.call('foobar', pdb_mock, FakeDatetime(2014, 6, 4, hour=4, minute=0, second=0, tzinfo=pytz.utc), FakeDatetime(2014, 6, 5, hour=3, minute=59, second=59, tzinfo=pytz.utc), cache_dir=None),
         ]
         assert dft_mock.mock_calls == dft_expected
 


### PR DESCRIPTION
In the case where this is running from one host against multiple puppetdb hosts (presumably in different environments/stacks), we need to include the hostname in the cache filename.
